### PR TITLE
package/nwipe: use tag as stable, use pre-configure hook

### DIFF
--- a/package/nwipe/Config.in
+++ b/package/nwipe/Config.in
@@ -26,27 +26,25 @@ choice
 	  Select which nwipe version (Git ref) should be built.
 
 config BR2_PACKAGE_NWIPE_VERSION_STABLE
-	bool "Stable commit (051e1aa)"
+	bool "Stable tag (v0.39)"
 	help
-	  Use the previously hard-coded commit (051e1aa) as a stable baseline.
+	  Use the previously hard-coded tag (v0.39) as a stable baseline.
 
 config BR2_PACKAGE_NWIPE_VERSION_GIT_REVISION
 	bool "Git revision"
 	help
-	  Use a user-specified Git revision (commit SHA-1 or tag).
+	  Use a user-specified Git revision (full commit SHA-1 or tag).
 
 endchoice
 
 config BR2_PACKAGE_NWIPE_GIT_REVISION
-	string "Git revision (commit SHA-1 or tag)"
+	string "Git revision (full commit SHA-1 or tag)"
 	depends on BR2_PACKAGE_NWIPE_VERSION_GIT_REVISION
 	help
 	  When 'Git revision' is selected above, this string is passed as the
 	  Git ref to check out. Examples:
-	    - 051e1aa        (commit SHA-1)
-	    - v0.39          (tag)
+	    - 051e1aa0c9572b26301a33d40689adb544927d11 (full commit SHA-1)
+	    - v0.39 (tag)
 
 endif
-
-comment "nwipe"
 

--- a/package/nwipe/nwipe.mk
+++ b/package/nwipe/nwipe.mk
@@ -6,12 +6,12 @@
 
 # Select the Git reference based on the Kconfig choice.
 ifeq ($(BR2_PACKAGE_NWIPE_VERSION_STABLE),y)
-NWIPE_VERSION = 051e1aa
+NWIPE_VERSION = v0.39
 else ifeq ($(BR2_PACKAGE_NWIPE_VERSION_GIT_REVISION),y)
 NWIPE_VERSION = $(call qstrip,$(BR2_PACKAGE_NWIPE_GIT_REVISION))
 else
 # Fallback – should not happen because the choice enforces exactly one option
-NWIPE_VERSION = 051e1aa
+NWIPE_VERSION = v0.39
 endif
 
 # Default Git repository URL (never empty).
@@ -31,7 +31,10 @@ define NWIPE_INITSH
 		PATH="../../host/bin:${PATH}" ./autogen.sh)
 endef
 
-NWIPE_POST_PATCH_HOOKS += NWIPE_INITSH
+# Pre-configure hook, as a post-patch hook would not get triggered on a package
+# reconfigure, and possibly also taint the sources directory with the generated
+# autogen files (which should not be there).
+NWIPE_PRE_CONFIGURE_HOOKS += NWIPE_INITSH
 
 $(eval $(autotools-package))
 


### PR DESCRIPTION
- A tag makes it immediately obvious what version we're dealing with.
- A pre-configure hook is better because post-patch hooks may not fire on package-reconfigure.